### PR TITLE
Shell out to git

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,2 @@
 {:paths ["src/main/clojure"]
- :deps 
- {org.clojure/clojure {:mvn/version "1.8.0"}
-  org.eclipse.jgit/org.eclipse.jgit {:mvn/version "4.10.0.201712302008-r"}
-  com.jcraft/jsch.agentproxy.connector-factory {:mvn/version "0.0.9"}
-  com.jcraft/jsch.agentproxy.jsch {:mvn/version "0.0.9"}}}
+ :deps {org.clojure/clojure {:mvn/version "1.8.0"}}}

--- a/pom.xml
+++ b/pom.xml
@@ -29,21 +29,6 @@
       <version>${clojure.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.eclipse.jgit</groupId>
-      <artifactId>org.eclipse.jgit</artifactId>
-      <version>4.10.0.201712302008-r</version>
-    </dependency>
-    <dependency>
-      <groupId>com.jcraft</groupId>
-      <artifactId>jsch.agentproxy.connector-factory</artifactId>
-      <version>0.0.9</version>
-    </dependency>
-    <dependency>
-      <groupId>com.jcraft</groupId>
-      <artifactId>jsch.agentproxy.jsch</artifactId>
-      <version>0.0.9</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/clojure/clojure/tools/gitlibs.clj
+++ b/src/main/clojure/clojure/tools/gitlibs.clj
@@ -14,11 +14,7 @@
   (:refer-clojure :exclude [resolve])
   (:require
     [clojure.java.io :as jio]
-    [clojure.tools.gitlibs.impl :as impl])
-  (:import
-    [org.eclipse.jgit.lib ObjectId]
-    [org.eclipse.jgit.revwalk RevWalk RevCommit]
-    [org.eclipse.jgit.errors MissingObjectException]))
+    [clojure.tools.gitlibs.impl :as impl]))
 
 (defn cache-dir
   "Return the root gitlibs cache directory. By default ~/.gitlibs or

--- a/src/main/clojure/clojure/tools/gitlibs.clj
+++ b/src/main/clojure/clojure/tools/gitlibs.clj
@@ -30,13 +30,7 @@
   "Takes a git url and a rev, and returns the full commit sha. rev may be a
   partial sha, full sha, or tag name."
   [url rev]
-  (let [git-dir (impl/ensure-git-dir url)]
-    (if (ObjectId/isId rev)
-      rev
-      (let [rev (.resolve (impl/git-repo git-dir) rev)]
-        (if rev
-          (.getName rev)
-          nil)))))
+  (impl/git-rev-parse (impl/ensure-git-dir url) rev))
 
 (defn procure
   "Procure a working tree at rev for the git url representing the library lib,

--- a/src/main/clojure/clojure/tools/gitlibs/impl.clj
+++ b/src/main/clojure/clojure/tools/gitlibs/impl.clj
@@ -24,30 +24,22 @@
   (binding [*out* *err*]
     (apply println msgs)))
 
-(def ^:private ^TransportConfigCallback ssh-callback
-  (delay
-    (let [factory (doto (ConnectorFactory/getDefault) (.setPreferredUSocketFactories "jna,nc"))
-          connector (.createConnector factory)]
-      (JSch/setConfig "PreferredAuthentications" "publickey")
-      (reify TransportConfigCallback
-        (configure [_ transport]
-          (.setSshSessionFactory ^SshTransport transport
-            (proxy [JschConfigSessionFactory] []
-              (configure [host session])
-              (getJSch [hc fs]
-                (doto (proxy-super getJSch hc fs)
-                  (.setIdentityRepository (RemoteIdentityRepository. connector)))))))))))
+(defn- runproc
+  [& args]
+  (let [proc (.start (ProcessBuilder. ^java.util.List args))
+        code (.waitFor proc)
+        out (slurp (.getInputStream proc))
+        err (slurp (.getErrorStream proc))]
+    (when-not (zero? code)
+      (printerrln args)
+      (printerrln err))
+    {:exit code
+     :out out
+     :err err}))
 
-(defn- call-with-auth
-  ([^GitCommand command]
-    (call-with-auth
-      (.. command getRepository getConfig (getString "remote" "origin" "url"))
-      command))
-  ([^String url ^GitCommand command]
-   (if (and (instance? TransportCommand command)
-         (not (str/starts-with? url "http")))
-     (.. ^TransportCommand command (setTransportConfigCallback @ssh-callback) call)
-     (.call command))))
+;; git clone --bare --quiet URL PATH
+;; git --git-dir <> fetch
+;; git --git-dir <> --work-tree <dst> checkout <rev>
 
 (defn git-repo
   (^Repository [git-dir]
@@ -59,20 +51,14 @@
        (.setWorkTree (jio/file rev-dir))))))
 
 (defn git-fetch
-  ^Git [git-dir]
-  (let [git (Git. (git-repo git-dir))]
-    (call-with-auth (.. git fetch))
-    git))
+  [^File git-dir]
+  (runproc "git" "--git-dir" (.getCanonicalPath git-dir) "fetch"))
 
 ;; TODO: restrict clone to an optional refspec?
 (defn git-clone-bare
-  [url git-dir]
+  [url ^File git-dir]
   (printerrln "Cloning:" url)
-  (call-with-auth url
-    (.. (Git/cloneRepository) (setURI url) (setGitDir (jio/file git-dir))
-      (setBare true)
-      (setNoCheckout true)
-      (setCloneAllBranches true)))
+  (runproc "git" "clone" "--bare" url (.getCanonicalPath git-dir))
   git-dir)
 
 (def ^:private CACHE
@@ -102,19 +88,26 @@
   [url]
   (let [git-dir (jio/file (cache-dir) "_repos" (clean-url url))]
     (if (.exists git-dir)
-      (try
-        (git-fetch git-dir)
-        (catch Throwable _
-          ;; if can't fetch, local cache may be corrupt, try recloning
-          (git-clone-bare url git-dir)))
+      (git-fetch git-dir)
       (git-clone-bare url git-dir))
     (.getCanonicalPath git-dir)))
 
 (defn git-checkout
-  [url rev-dir ^String rev]
-  (let [git-dir (ensure-git-dir url)
-        git (Git. (git-repo git-dir rev-dir))]
-    (call-with-auth (.. git checkout (setStartPoint rev) (setAllPaths true)))))
+  [url ^File rev-dir ^String rev]
+  (when-not (.exists rev-dir)
+    (.mkdirs rev-dir))
+  (runproc "git"
+           "--git-dir" (ensure-git-dir url)
+           "--work-tree" (.getCanonicalPath rev-dir)
+           "checkout" rev))
+
+(defn git-rev-parse
+  [git-dir rev]
+  (let [p (runproc "git"
+                   "--git-dir" git-dir
+                   "rev-parse" rev)]
+    (when (zero? (:exit p))
+      (:out p))))
 
 (defn commit-comparator
   [^RevWalk walk ^RevCommit x ^RevCommit y]

--- a/src/main/clojure/clojure/tools/gitlibs/impl.clj
+++ b/src/main/clojure/clojure/tools/gitlibs/impl.clj
@@ -12,13 +12,7 @@
     [clojure.java.io :as jio]
     [clojure.string :as str])
   (:import
-    [java.io File FilenameFilter IOException]
-    [org.eclipse.jgit.api Git GitCommand TransportCommand TransportConfigCallback]
-    [org.eclipse.jgit.lib Repository RepositoryBuilder]
-    [org.eclipse.jgit.revwalk RevWalk RevCommit]
-    [org.eclipse.jgit.transport SshTransport JschConfigSessionFactory]
-    [com.jcraft.jsch JSch]
-    [com.jcraft.jsch.agentproxy Connector ConnectorFactory RemoteIdentityRepository]))
+    [java.io File FilenameFilter IOException]))
 
 (defn printerrln [& msgs]
   (binding [*out* *err*]
@@ -40,15 +34,6 @@
 ;; git clone --bare --quiet URL PATH
 ;; git --git-dir <> fetch
 ;; git --git-dir <> --work-tree <dst> checkout <rev>
-
-(defn git-repo
-  (^Repository [git-dir]
-   (.build (.setGitDir (RepositoryBuilder.) (jio/file git-dir))))
-  (^Repository [git-dir rev-dir]
-   (.build
-     (doto (RepositoryBuilder.)
-       (.setGitDir (jio/file git-dir))
-       (.setWorkTree (jio/file rev-dir))))))
 
 (defn git-fetch
   [^File git-dir]

--- a/src/main/clojure/clojure/tools/gitlibs/impl.clj
+++ b/src/main/clojure/clojure/tools/gitlibs/impl.clj
@@ -31,7 +31,7 @@
         out (slurp (.getInputStream proc))
         err (slurp (.getErrorStream proc))]
     (when-not (zero? code)
-      (printerrln args)
+      (apply printerrln args)
       (printerrln err))
     {:exit code
      :out out


### PR DESCRIPTION
*notes on git deps with `clj`*
`https` _with authentication_ is not supported yet by `clj`
`ssh` authentication via Java is a usability trashfire (some KEX methods unsupported)
The terminal is not interactive in `clojure`, so you cannot accept unseen public host keys - this might be ok, but surprising.
Esoteric `.ssh/config` options can break cloning because the underlying java ssh libraries misread the .ssh/config file
ed25519 keys supported via ssh-agent, but not via ~/.ssh/config entries
Porting to shell out to `git` would help all of these issues, if remains compatible with Windows support